### PR TITLE
Install dependencies from requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,13 @@
 from setuptools import setup
+from pathlib import Path
+
+this_dir = Path(__file__).resolve().parent
+with (this_dir / "requirements.txt").open() as rf: 
+    install_requires = [ 
+        req.strip()
+        for req in rf.readlines()
+        if req.strip() and not req.startswith("#")
+    ]   
 
 setup(
     name="TemplateFitter",
@@ -9,4 +18,5 @@ setup(
         "templatefitter"
     ],
     description="Perform extended binnend log-likelhood fits using histogram templates as pdfs.",
+    install_requires=install_requires
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from pathlib import Path
 
 this_dir = Path(__file__).resolve().parent
@@ -14,9 +14,7 @@ setup(
     version="0.0.1",
     author="Maximilian Welsch",
     url="https://github.com/welschma/TemplateFitter",
-    packages=[
-        "templatefitter"
-    ],
+    packages=find_packages(),
     description="Perform extended binnend log-likelhood fits using histogram templates as pdfs.",
     install_requires=install_requires
 )


### PR DESCRIPTION
Without this, the dependencies aren't automatically installed (as is the expected behavior).

With this PR, ``pip install -....`` will automatically take care of it.
That then also makes it easy to add templatefitter as a dependency of other projects.